### PR TITLE
#5 Fixed typing for the initial state in useState

### DIFF
--- a/types/useState.d.ts
+++ b/types/useState.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="react" />
-export declare const useState: <S>(initialState: () => S, id: string | number) => [S, import("react").Dispatch<import("react").SetStateAction<S>>];
+export declare const useState: <S>(
+    initialState: S | (() => S),
+    id: string | number
+) => [S, import('react').Dispatch<import('react').SetStateAction<S>>];


### PR DESCRIPTION
Fixed the types for the initial state from useState hook.
I used the official types from [react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts). (Line 846)