### PR TITLE
Fix: Remove initializer's initial assignment

### DIFF
--- a/src/useReducer.ts
+++ b/src/useReducer.ts
@@ -100,7 +100,7 @@ export function useReducer<R extends Reducer<any, any>, I>(
   ...args: any[]
 ) {
   let id: string | number | undefined
-  let initializer: (arg: I | (I & ReducerState<R>)) => ReducerState<R> = args[0]
+  let initializer: (arg: I | (I & ReducerState<R>)) => ReducerState<R>
 
   if (args.length === 2) {
     initializer = args[0]


### PR DESCRIPTION
when I run the following pattern: `useReducer(reducer, state, 'name');` I get the following error:

<img width="616" alt="Screen Shot 2020-08-28 at 4 27 10 PM" src="https://user-images.githubusercontent.com/1064889/91521310-78feb980-e94b-11ea-8b69-80862195f79c.png">

The change I proposed is to leave assigning `initializer` to the if/else conditions below the line