### PR TITLE
Add `children: ReactNode` prop to the `StateInspectorProps` type

### DIFF
--- a/src/StateInspector.tsx
+++ b/src/StateInspector.tsx
@@ -11,6 +11,7 @@ declare global {
 interface StateInspectorProps {
   name?: string
   initialState?: any
+  children?: React.ReactNode
 }
 
 interface StoreReducerAction {


### PR DESCRIPTION
As noted in the issue below, currently inserting React Nodes as a children prop into the StateInspector component will result with a TypeError. https://github.com/troch/reinspect/issues/83

This is an issue for React >18 only, as noted in the stackoverflow below, the React.FC type does not include the children: ReactNode anymore. https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71800185#71800185